### PR TITLE
fix(Performance): Improvement

### DIFF
--- a/Sources/MetadataHDWalletKit/Wallet/PrivateKey.swift
+++ b/Sources/MetadataHDWalletKit/Wallet/PrivateKey.swift
@@ -18,6 +18,8 @@ enum PrivateKeyType {
     case nonHd
 }
 
+let secp256k1CurveOrder = BInt(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")!
+
 public struct PrivateKey {
     public let raw: Data
     public let chainCode: Data
@@ -150,8 +152,7 @@ public struct PrivateKey {
         let digest = Crypto.HMACSHA512(key: chainCode, data: data)
         let factor = BInt(data: digest[0..<32])
 
-        let curveOrder = BInt(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")!
-        let derivedPrivateKey = ((BInt(data: raw) + factor) % curveOrder).data
+        let derivedPrivateKey = ((BInt(data: raw) + factor) % secp256k1CurveOrder).data
         let derivedChainCode = digest[32..<64]
 
         let depth = depth + 1


### PR DESCRIPTION
Calculate `secp256k1` curve order once and reuse

Baseline was from a test with the curve order calculated every time the derive method was accessed, the average was without

<img width="275" alt="Screenshot 2023-11-01 at 13 55 31" src="https://github.com/paulo-bc/MetadataHDWalletKit/assets/71259279/e83ce2fa-7c1c-4be1-a145-4822d915ed3e">
