### PR TITLE
Forces compiler to use [UInt8] instead of new bytes: RawSpan value of Data

### DIFF
--- a/Sources/MetadataHDWalletKit/Core/Crypto/Encryption/EllipticCurveEncrypterSecp256k1.swift
+++ b/Sources/MetadataHDWalletKit/Core/Crypto/Encryption/EllipticCurveEncrypterSecp256k1.swift
@@ -27,7 +27,7 @@ public class EllipticCurveEncrypterSecp256k1 {
     ///   - privateKey: private key bytes
     /// - Returns: public key structure
     public func createPublicKey(privateKey: Data) -> secp256k1_pubkey {
-        let privateKey = privateKey.bytes
+        let privateKey: [UInt8] = privateKey.bytes
         var publickKey = secp256k1_pubkey()
         _ = SecpResult(secp256k1_ec_pubkey_create(context, &publickKey, privateKey))
         return publickKey
@@ -94,7 +94,7 @@ public class EllipticCurveEncrypterSecp256k1 {
     /// - Returns: public key structure or nil, if signature invalid
     public func publicKey(signature: inout secp256k1_ecdsa_recoverable_signature, hash: Data) -> secp256k1_pubkey? {
         precondition(hash.count == 32, "Hash must be 32 bytes size")
-        let hash = hash.bytes
+        let hash: [UInt8] = hash.bytes
         var outPubKey = secp256k1_pubkey()
         let status = SecpResult(secp256k1_ecdsa_recover(context, &outPubKey, &signature, hash))
         return status == .success ? outPubKey : nil

--- a/Sources/MetadataHDWalletKit/Wallet/PrivateKey.swift
+++ b/Sources/MetadataHDWalletKit/Wallet/PrivateKey.swift
@@ -321,7 +321,7 @@ extension PrivateKey {
 
         let checksum = Array(decoded.bytes[78..<82])
         let bytes = Array(decoded.bytes[0..<78])
-        let hash = Data(bytes).doubleSHA256.prefix(4).bytes
+        let hash: [UInt8] = Data(bytes).doubleSHA256.prefix(4).bytes
 
         guard hash[0..<4] == checksum[0..<4] else {
             return .failure(.decodingError)


### PR DESCRIPTION
Swift 6.2 introduced a new `bytes` variable on Data with type of RawSpan, this forces the compiler to use [Uint8] instead of RawSpan